### PR TITLE
Added ARK base class along with CMake setup

### DIFF
--- a/ark_import.cmake
+++ b/ark_import.cmake
@@ -1,0 +1,42 @@
+#
+#                                        ::                                                      
+#                                        ::                                                      
+#                                        ::                                                      
+#                                        ::                                                      
+#                                        ::                                                      
+#    ..    ..........    :.      ::      ::     .........  ..    ..........    ...      .        
+#    ::    ::            : .:.   ::     .::.       ::      ::    ::       :    :: :.    :        
+#    ::    ::   ..:::    :   .:. ::    ::::::      ::      ::    ::       :    ::   ::  :        
+#    ::    ::......::    :      :::    ::::::      ::      ::    ::.......:    ::     :::        
+#                                      ::::::                                                    
+#                                      :.::.:                                                    
+#                         .::::          ::          ::::.                                       
+#                       .::::::::.       ::       .:::::::::                                     
+#                       ::::::::::::....::::.....:::::::::::                                     
+#                        .:::::::::::::::::::::::::::::::::.                                     
+#                                                                                                
+#                  © Copyright of Ignition Software                                              
+#                                                                                                
+#************************************************************************************************
+#* File:        ark_import.cmake
+#* Brief:
+#* User-facing ARK import entry point.
+#*
+#* Description:
+#* This file is intended to be included by external projects using ARK.
+#* It imports and initializes the Pico SDK and pulls in the ARK kernel
+#* implementation. This file must be included exactly once.
+#***************************************************************************************************
+
+# Prevent double inclusion
+if (DEFINED ARK_IMPORTED)
+	return()
+endif()
+set(ARK_IMPORTED TRUE)
+
+# Import Pico SDK
+include(${CMAKE_CURRENT_LIST_DIR}/pico_sdk_import.cmake)
+pico_sdk_init()
+
+# Add ARK kernel
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/core)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,0 +1,55 @@
+#
+#                                        ::                                                      
+#                                        ::                                                      
+#                                        ::                                                      
+#                                        ::                                                      
+#                                        ::                                                      
+#    ..    ..........    :.      ::      ::     .........  ..    ..........    ...      .        
+#    ::    ::            : .:.   ::     .::.       ::      ::    ::       :    :: :.    :        
+#    ::    ::   ..:::    :   .:. ::    ::::::      ::      ::    ::       :    ::   ::  :        
+#    ::    ::......::    :      :::    ::::::      ::      ::    ::.......:    ::     :::        
+#                                      ::::::                                                    
+#                                      :.::.:                                                    
+#                         .::::          ::          ::::.                                       
+#                       .::::::::.       ::       .:::::::::                                     
+#                       ::::::::::::....::::.....:::::::::::                                     
+#                        .:::::::::::::::::::::::::::::::::.                                     
+#                                                                                                
+#                  © Copyright of Ignition Software                                              
+#                                                                                                
+#************************************************************************************************
+#* File:        CMakeLists.txt
+#* Author:      Abhinav Kuruvila Joseph
+#* Created On:  2025-12-29
+#* Brief:
+#* ARK kernel build definition.
+#*
+#* Description:
+#* Defines the ARK kernel as a static library. This file does not perform
+#* any SDK initialization or define executables. It is added to the build
+#* exclusively through ark_import.cmake.
+#***************************************************************************************************
+#* HISTORY:
+#* * +----- (NEW | MODify | ADD | DELete)
+#* |
+#* No#   |  Type  |       Date       | Author              | Description
+#******+*********+*******************+*********************+***************************************
+#* 000  |  NEW   |  2025-12-29        | Abhinav Kuruvila   | Initial creation
+#**************************************************************************************************/
+
+add_library(ark)
+
+target_sources(ark
+	PRIVATE
+		ark.cpp
+)
+
+target_include_directories(ark
+	PUBLIC
+    	${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_compile_features(ark
+	PUBLIC
+		cxx_std_17
+)

--- a/core/ark.cpp
+++ b/core/ark.cpp
@@ -1,0 +1,107 @@
+/*
+                                        ::                                                      
+                                        ::                                                      
+                                        ::                                                      
+                                        ::                                                      
+                                        ::                                                      
+    ..    ..........    :.      ::      ::     .........  ..    ..........    ...      .        
+    ::    ::            : .:.   ::     .::.       ::      ::    ::       :    :: :.    :        
+    ::    ::   ..:::    :   .:. ::    ::::::      ::      ::    ::       :    ::   ::  :        
+    ::    ::......::    :      :::    ::::::      ::      ::    ::.......:    ::     :::        
+                                      ::::::                                                    
+                                      :.::.:                                                    
+                         .::::          ::          ::::.                                       
+                       .::::::::.       ::       .:::::::::                                     
+                       ::::::::::::....::::.....:::::::::::                                     
+                        .:::::::::::::::::::::::::::::::::.                                     
+                                                                                                
+                  © Copyright of Ignition Software
+
+************************************************************************************************
+* File:        ark.cpp
+* Brief:
+* Implementation of the ARK kernel.
+* Description:
+* Implements kernel lifecycle control including initialization,
+* execution, and halt mechanisms.
+************************************************************************************************
+
+/*==============================================================================================
+ * Includes
+ *============================================================================================*/
+#include "ark.h"
+
+/*==============================================================================================
+ * Function Definitions
+ *============================================================================================*/
+
+ResultCode ARK::Init(const ArkConfig* pConfig)
+{
+    if (mIsInitialized == true)
+    {
+        return RESULT_ALREADY_INITIALIZED;
+    }
+
+    if (ValidateConfig(pConfig) == false)
+    {
+        return RESULT_INVALID_PARAM;
+    }
+
+    mConfig = *pConfig;
+    mIsInitialized = true;
+    mIsRunning = false;
+
+    return RESULT_OK;
+}
+
+ResultCode ARK::Run(void)
+{
+    if (mIsInitialized == false)
+    {
+        return RESULT_NOT_INITIALIZED;
+    }
+
+    if (mIsRunning == true)
+    {
+        return RESULT_INTERNAL_ERROR;
+    }
+
+    mIsRunning = true;
+
+    // TODO: Hand over to StateManager here
+
+
+    return RESULT_INTERNAL_ERROR;
+}
+
+ResultCode ARK::Halt(void)
+{
+    if (mIsInitialized == false)
+    {
+        return RESULT_NOT_INITIALIZED;
+    }
+
+    mIsRunning = false;
+
+    return RESULT_OK;
+}
+
+/*==============================================================================================
+ * Private Function Definitions
+ *============================================================================================*/
+
+bool ARK::ValidateConfig(const ArkConfig* pConfig)
+{
+    if (pConfig == NULL)
+    {
+        return false;
+    }
+
+    if (pConfig->expectedAltitudeMeters == 0U)
+    {
+        return false;
+    }
+
+    return true;
+}
+

--- a/core/ark.h
+++ b/core/ark.h
@@ -1,0 +1,112 @@
+/*
+                                        ::                                                      
+                                        ::                                                      
+                                        ::                                                      
+                                        ::                                                      
+                                        ::                                                      
+    ..    ..........    :.      ::      ::     .........  ..    ..........    ...      .        
+    ::    ::            : .:.   ::     .::.       ::      ::    ::       :    :: :.    :        
+    ::    ::   ..:::    :   .:. ::    ::::::      ::      ::    ::       :    ::   ::  :        
+    ::    ::......::    :      :::    ::::::      ::      ::    ::.......:    ::     :::        
+                                      ::::::                                                    
+                                      :.::.:                                                    
+                         .::::          ::          ::::.                                       
+                       .::::::::.       ::       .:::::::::                                     
+                       ::::::::::::....::::.....:::::::::::                                     
+                        .:::::::::::::::::::::::::::::::::.                                     
+                                                                                                
+                  © Copyright of Ignition Software
+************************************************************************************************
+* File:        ark.h
+* Brief:
+* Public interface for the ARK kernel.
+* Description:
+* Defines the ARK kernel class responsible for initialization,
+* execution, and halt.
+************************************************************************************************
+
+#ifndef ARK_H
+#define ARK_H
+
+/*==============================================================================================
+ * Includes
+ *============================================================================================*/
+#include <stdint.h>
+#include <stdbool.h>
+
+/*==============================================================================================
+ * Enumerations
+ *=============================================================================================/
+typedef enum
+{
+    RESULT_OK = 0,
+    RESULT_INVALID_PARAM,
+    RESULT_NOT_INITIALIZED,
+    RESULT_ALREADY_INITIALIZED,
+    RESULT_INTERNAL_ERROR
+} ResultCode;
+
+/*==============================================================================================
+ * Typedefs / Structures
+ *============================================================================================*/
+typedef struct
+{
+    uint32_t expectedAltitudeMeters;
+    // TODO: fill other flight configurations
+} ArkConfig;
+
+/*==============================================================================================
+ * Class Declaration
+ *============================================================================================*/
+class ARK
+{
+public:
+    /**
+     * \brief   Initializes the ARK kernel.
+     * \details Validates configuration and prepares internal kernel state.
+     *
+     * \param[in] pConfig Pointer to kernel configuration.
+     * \return    RESULT_OK if successful.
+     *
+     * \pre       Kernel must not be initialized.
+     * \post      Kernel enters initialized state.
+     */
+    ResultCode Init(const ArkConfig* pConfig);
+
+    /**
+     * \brief   Starts kernel-controlled execution.
+     * \details Enters execution loop owned by ARK's StateManager.
+     *
+     * \return    RESULT_OK if execution begins successfully.
+     *
+     * \pre       Init() must have completed successfully.
+     * \post      Kernel is running.
+     */
+    ResultCode Run(void);
+
+    /**
+     * \brief   Halts kernel execution safely.
+     * \details Stops execution and transitions kernel to a safe state.
+     *
+     * \return    RESULT_OK if halt is successful.
+     *
+     * \pre       Kernel must be initialized.
+     * \post      Kernel execution is halted.
+     */
+    ResultCode Halt(void);
+
+private:
+    bool mIsInitialized;
+    bool mIsRunning;
+    ArkConfig mConfig;
+
+    /**
+     * \brief   Validates ARK configuration.
+     *
+     * \param[in] pConfig Pointer to configuration to validate.
+     * \return    true if configuration is valid, false otherwise.
+     */
+    bool ValidateConfig(const ArkConfig* pConfig);
+};
+
+#endif /* ARK_H */


### PR DESCRIPTION
This PR adds the initial ARK kernel base along with the CMake setup required to utilize ARK in a separate project as a submodule.